### PR TITLE
docs: remove broken Bako ID link from homepage

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -12,11 +12,6 @@ Through our comprehensive packages, users can effortlessly integrate vault opera
 - **[Bako Safe SDK](./sdk/quick-start):** the heart of Bako Safe offers a robust suite of functionalities for vault management, transaction processes, and modern secure authentication options, incorporating essential wallet operations with ease.
 - **[Bako Wallet Connector](./connector/quick-start/installation)**: this package provides a seamless bridge for integrating our shared wallet functionalities into external applications, enhancing user experience and operational efficiency.
 
-### **Extending Bako ecosystem functionality**
-
-- **[Bako ID](https://docs.bako.id/)**: Integrating Bako Safe with Bako ID, our identity solution for RollupOS, greatly enhances user experience.
-  - Bako ID Documentation
-
 ### **Getting in touch with the Bako team**
 
 Despite Bako’s focus on performance and security, it's an evolving solution and we would love to hear your feedback. Thus, we encourage conversation via our channels:


### PR DESCRIPTION
## Summary
- Remove the "Extending Bako ecosystem functionality" section from homepage
- The link to https://docs.bako.id/ is broken and no longer valid

## Test plan
- [ ] Verify homepage renders without the Bako ID section
- [ ] Confirm no broken links remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)